### PR TITLE
Add retry and formatted state tracking to logger

### DIFF
--- a/src/middleware/logger/inc/logger.h
+++ b/src/middleware/logger/inc/logger.h
@@ -34,6 +34,7 @@ typedef struct
     uint32_t timestamp;                        /**< Log timestamp */
     bool in_use;                               /**< Allocation flag */
     bool is_const;                             /**< Is message stored in flash */
+    bool is_formatted;                         /**< Timestamp already prepended */
 } Logger_Entry_T;
 
 typedef struct Logger_Context_Tag
@@ -70,6 +71,11 @@ void logger_trigger_highprio(Logger_Context_T *ctx, uint8_t idx, uint32_t timest
 
 /**
  * @brief Logger transmission scheduler (called by logger task)
+ *
+ * Attempts to transmit the next pending log entry. If the underlying
+ * UartDma_Transmit() call fails, the entry remains queued/registered and
+ * the logger task is notified to retry. Retries continue until the
+ * transmission succeeds.
  */
 void logger_tx_scheduler(Logger_Context_T *ctx);
 


### PR DESCRIPTION
## Summary
- track whether a log entry already includes its timestamp
- clear the flag when logs are reused
- only format when needed and retry transmissions on failure
- document new retry behaviour

## Testing
- `cmake -S src -B build` *(fails: Hal_Drv missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b2715508323ae73e5ac96cadedf