### PR TITLE
Fix toolchain and library path

### DIFF
--- a/src/_cmake/toolchain.cmake
+++ b/src/_cmake/toolchain.cmake
@@ -1,7 +1,9 @@
 # ------------------------------------------------------------------------------
 # Cross-Compile Settings
 # ------------------------------------------------------------------------------
-set(STM32_LINKER_SCRIPT "C:/STM32N6/03_Repos/proj/src/_cmake/ld_script/STM32N657X0HXQ_AXISRAM2_fsbl.ld")
+# Path to the linker script relative to this toolchain file so it works on any
+# host and does not rely on a hard coded Windows path.
+set(STM32_LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/ld_script/STM32N657X0HXQ_AXISRAM2_fsbl.ld")
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)  # Ensure no host system linking

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -4,7 +4,9 @@ cmake_minimum_required(VERSION 3.22)
 set(COMPONENT_NAME "libs_layer")
 
 # Subdirs 
-add_subdirectory(Hal_Drv ${CMAKE_BINARY_DIR}/HAL_Drv)
+# The directory is called "HAL_Drv" in this repository. Use the correct
+# casing so configuration succeeds on case-sensitive file systems.
+add_subdirectory(HAL_Drv ${CMAKE_BINARY_DIR}/HAL_Drv)
 add_subdirectory(CMSIS ${CMAKE_BINARY_DIR}/CMSIS)
 
 


### PR DESCRIPTION
## Summary
- fix HAL library directory name so CMake finds it
- make linker script path relative so the toolchain works on Linux

## Testing
- `cmake -S src -B build -DCMAKE_TOOLCHAIN_FILE=$(pwd)/src/_cmake/toolchain.cmake -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -- --no-print-directory`

------
https://chatgpt.com/codex/tasks/task_e_683f6f55e30c832385277ccf74e4b84f