### PR TITLE
Add VSCode dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:22.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y \
+        cmake \
+        make \
+        ninja-build \
+        gcc-arm-none-eabi \
+        gdb-multiarch \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional: add other tools if needed
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "name": "STM32 build container",
+    "dockerFile": "Dockerfile",
+    "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+    },
+    "extensions": [
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools"
+    ],
+    "postCreateCommand": "mkdir -p build"
+}


### PR DESCRIPTION
## Summary
- add `.devcontainer` with Dockerfile installing GCC arm toolchain and cmake
- configure `devcontainer.json` for VSCode build environment

## Testing
- `cmake -S src -B build -DCMAKE_TOOLCHAIN_FILE=$(pwd)/src/_cmake/toolchain.cmake`
- `cmake --build build -- --no-print-directory`


------
https://chatgpt.com/codex/tasks/task_e_684206ff5d2c8323bbc1edc7dffb12f4