### PR TITLE
Refactor high priority logging

### DIFF
--- a/src/app/DevM/src/DevM_PreOS.c
+++ b/src/app/DevM/src/DevM_PreOS.c
@@ -140,7 +140,7 @@ static DevM_ReturnType DevM_StateInitBswPreOS(void)
  */
 static DevM_ReturnType DevM_StateInitMiddlewarePreOS(void)
 {
-
+    Cfg_Logger_Init();
     return DEVM_OK;
 }
 /**

--- a/src/app/SysM/inc/SysM.h
+++ b/src/app/SysM/inc/SysM.h
@@ -24,4 +24,9 @@
  */
 Logger_Context_T *Cfg_Logger_GetContext(void);
 
+/**
+ * @brief Initialize the application logger and register static messages.
+ */
+void Cfg_Logger_Init(void);
+
 #endif /* SYSM_H */

--- a/src/app/SysM/src/SysM.c
+++ b/src/app/SysM/src/SysM.c
@@ -7,6 +7,8 @@
 
 /* Includes -----------------------------------------------------------------*/
 #include "logger.h"
+#include <stdbool.h>
+#include "cfg_logger.h"
 /* Defines ------------------------------------------------------------------*/
 
 /* Local Types and Typedefs -------------------------------------------------*/
@@ -16,6 +18,8 @@
  * @brief Statically allocated application logger context.
  */
 static Logger_Context_T logger_context = LOGGER_CONTEXT_INIT;
+
+LOGGER_DEFINE_HIGHPRIO_ENTRY(hp_queue_full, CFG_LOGGER_HP_QUEUE_FULL_MSG);
 
 /* Private Function Prototypes ----------------------------------------------*/
 
@@ -28,6 +32,13 @@ static Logger_Context_T logger_context = LOGGER_CONTEXT_INIT;
 Logger_Context_T *Cfg_Logger_GetContext(void)
 {
     return &logger_context;
+}
+
+void Cfg_Logger_Init(void)
+{
+    logger_register_highprio(&logger_context,
+                             CFG_LOGGER_HP_QUEUE_FULL_IDX,
+                             &hp_queue_full);
 }
 /* Private Functions Implementation -----------------------------------------*/
 /**

--- a/src/app/test_swc/src/test_swc.c
+++ b/src/app/test_swc/src/test_swc.c
@@ -11,6 +11,7 @@
 #include "test_swc.h"
 #include "UartDma.h" // Include UART DMA header for testing
 #include "logger.h"  // Include logger for logging messages
+#include "cfg_logger.h" // Logger configuration
 #include "SysM.h"    // Include System Manager API for system services
 #include <string.h>  // For string operations
 
@@ -43,11 +44,9 @@ void TestSWC_Init(void)
 static void TestTask(void *pvParameters)
 {
     (void)pvParameters;
-    static Logger_Entry_T full_entry = {.msg = "Queue FULL\r\n", .length = 16};
 
     TickType_t xLastWakeTime = xTaskGetTickCount();
     Logger_Context_T *loggerCtx = Cfg_Logger_GetContext();
-    logger_register_highprio(loggerCtx, 0, &full_entry); // Register a high-priority log entry
 
     for (;;)
     {
@@ -59,11 +58,11 @@ static void TestTask(void *pvParameters)
 
             // logger_debug_push(loggerCtx, xTaskGetTickCount()); // Push the current tick count to the debug buffer
             logger_commit_entry(loggerCtx, entry);                      // Commit the log entry for transmission
-            logger_trigger_highprio(loggerCtx, 0, xTaskGetTickCount()); // Trigger high-priority log if allocation fails
+            logger_trigger_highprio(loggerCtx, CFG_LOGGER_HP_QUEUE_FULL_IDX, xTaskGetTickCount());
         }
         else
         {
-            logger_trigger_highprio(loggerCtx, 0, xTaskGetTickCount()); // Trigger high-priority log if allocation fails
+            logger_trigger_highprio(loggerCtx, CFG_LOGGER_HP_QUEUE_FULL_IDX, xTaskGetTickCount());
         }
         vTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(TEST_TASK_PERIOD_MS));
     }

--- a/src/cfg/inc/cfg_logger.h
+++ b/src/cfg/inc/cfg_logger.h
@@ -16,6 +16,11 @@
 #define CFG_LOGGER_LOG_QUEUE_SIZE (32U)         /**< Default size of the log queue */
 #define CFG_LOGGER_DEBUG_BUFFER_SIZE (128U)      /**< Default size of the debug value buffer */
 
+/** Index of the "queue full" high priority message. */
+#define CFG_LOGGER_HP_QUEUE_FULL_IDX (0U)
+/** Text of the "queue full" high priority message. */
+#define CFG_LOGGER_HP_QUEUE_FULL_MSG "Queue FULL\r\n"
+
 /* Typedefs -----------------------------------------------------------------*/
 
 #endif /* CFGCONST_LOGGER_H */

--- a/src/middleware/logger/inc/logger.h
+++ b/src/middleware/logger/inc/logger.h
@@ -27,6 +27,22 @@
     .debug_idx = 0}
 
 /**
+ * @brief Convenience macro for defining static high-priority log entries.
+ *
+ * This helper should only be used for high-priority messages that are
+ * statically allocated. Regular log entries must be obtained via
+ * ::logger_alloc_entry so they are taken from the internal memory pool.
+ */
+#define LOGGER_DEFINE_HIGHPRIO_ENTRY(name, literal) \
+    static Logger_Entry_T name = {                 \
+        .msg = literal,                            \
+        .length = sizeof(literal) - 1,             \
+        .base_length = sizeof(literal) - 1,        \
+        .in_use = false,                           \
+        .is_formatted = false                     \
+    }
+
+/**
  * @brief Log entry structure
  */
 typedef struct

--- a/src/middleware/logger/src/logger.c
+++ b/src/middleware/logger/src/logger.c
@@ -124,6 +124,10 @@ void logger_tx_scheduler(Logger_Context_T *ctx)
             }
             return;
         }
+        else
+        {
+            __atomic_and_fetch(&(ctx->high_prio_mask), ~(1u << idx), __ATOMIC_RELAXED);
+        }
     }
 
     // 2. Normal log queue


### PR DESCRIPTION
## Summary
- add LOGGER_DEFINE_ENTRY helper to simplify static Logger_Entry_T creation
- add queue-full message macros to cfg
- create prepared high priority entry in SysM and auto-register it
- use the configured index in test_swc
- clear unused bits in high priority scheduler

## Testing
- `mkdir build && cmake --build build -- --no-print-directory` *(fails: cannot create directory)*
- `cmake -S src -B build`
- `cmake --build build -- --no-print-directory` *(fails: invalid instruction suffix for `ds`)*

------
https://chatgpt.com/codex/tasks/task_e_6845f403fb588323b5268547e735434b