### PR TITLE
Add deterministic log prefix buffer

### DIFF
--- a/src/middleware/logger/inc/logger.h
+++ b/src/middleware/logger/inc/logger.h
@@ -35,11 +35,12 @@
  */
 #define LOGGER_DEFINE_HIGHPRIO_ENTRY(name, literal) \
     static Logger_Entry_T name = {                 \
-        .msg = literal,                            \
-        .length = sizeof(literal) - 1,             \
-        .base_length = sizeof(literal) - 1,        \
-        .in_use = false,                           \
-        .is_formatted = false                     \
+        .prefix = {0},                            \
+        .msg = literal,                           \
+        .length = sizeof(literal) - 1,            \
+        .base_length = sizeof(literal) - 1,       \
+        .in_use = false,                          \
+        .is_formatted = false                    \
     }
 
 /**
@@ -47,6 +48,7 @@
  */
 typedef struct
 {
+    char prefix[LOGGER_PREFIX_SIZE];             /**< Formatted prefix */
     uint8_t msg[LOGGER_LOG_ENTRY_BUFFER_SIZE]; /**< Log message text */
     uint8_t length;                            /**< Length of the message */
     uint8_t base_length;                       /**< Length of the template message */

--- a/src/middleware/logger/inc/logger_cfg.h
+++ b/src/middleware/logger/inc/logger_cfg.h
@@ -23,4 +23,8 @@
 #define LOGGER_DEBUG_BUFFER_SIZE (1024U) /**< Default size of the debug value buffer */
 #endif
 
+#ifndef LOGGER_PREFIX_SIZE
+#define LOGGER_PREFIX_SIZE (8U) /**< Fixed size of the formatted prefix */
+#endif
+
 #endif // LOGGER_CFG_H

--- a/src/middleware/logger/src/logger.c
+++ b/src/middleware/logger/src/logger.c
@@ -46,6 +46,7 @@ Logger_Entry_T *logger_alloc_entry(Logger_Context_T *ctx)
         {
 
             ctx->regular_log_pool[i].is_formatted = false;
+            memset(ctx->regular_log_pool[i].prefix, 0, LOGGER_PREFIX_SIZE);
             return &(ctx->regular_log_pool[i]);
         }
     }
@@ -77,13 +78,7 @@ void logger_trigger_highprio(Logger_Context_T *ctx, uint8_t idx, uint32_t timest
     if (!entry)
         return;
 
-    if (entry->length > entry->base_length)
-    {
-        uint8_t diff = entry->length - entry->base_length;
-        memmove(entry->msg, entry->msg + diff, entry->base_length);
-        memset(entry->msg + entry->base_length, 0, diff);
-        entry->length = entry->base_length;
-    }
+    memset(entry->prefix, 0, LOGGER_PREFIX_SIZE);
     entry->timestamp = timestamp;
     entry->in_use = true;
     entry->is_formatted = false;
@@ -109,7 +104,7 @@ void logger_tx_scheduler(Logger_Context_T *ctx)
             bool isSent = false;
             if (format_log_entry(entry))
             {
-                isSent = UartDma_Transmit((uint8_t *)&entry->msg[0], entry->length);
+                isSent = UartDma_Transmit((uint8_t *)&entry->prefix[0], entry->length + LOGGER_PREFIX_SIZE);
             }
             else
             {
@@ -142,7 +137,7 @@ void logger_tx_scheduler(Logger_Context_T *ctx)
         bool isReady = entry->is_formatted ? true : format_log_entry(entry);
         if (isReady)
         {
-            isSent = UartDma_Transmit((uint8_t *)&entry->msg[0], entry->length);
+            isSent = UartDma_Transmit((uint8_t *)&entry->prefix[0], entry->length + LOGGER_PREFIX_SIZE);
         }
 
         if (isSent)
@@ -243,40 +238,24 @@ static inline Logger_Entry_T *peek_normal_log(Logger_Context_T *ctx)
 }
 
 /**
- * @brief Prepends a timestamp to a log entry's message buffer in-place.
+ * @brief Format a log entry's prefix with the timestamp.
  * @param entry Pointer to the Logger_Entry_T to modify.
- * @return true if formatting succeeded, false if buffer would overflow.
+ * @return true if formatting succeeded.
  */
 static bool format_log_entry(Logger_Entry_T *entry)
 {
     uint32_t ts = entry->timestamp;
-    char ts_buf[12]; // e.g., "[123456] "
-    uint8_t ts_len = 0;
-
-    ts_buf[ts_len++] = '[';
-    uint32_t div = 1000000000;
-    bool started = false;
-    while (div > 0)
+    entry->prefix[0] = '[';
+    for (int i = 6; i >= 1; i--)
     {
-        uint32_t digit = ts / div;
-        if (digit || started || div == 1)
-        {
-            ts_buf[ts_len++] = '0' + digit;
-            started = true;
-        }
-        ts = ts % div;
-        div /= 10;
+        entry->prefix[i] = '0' + (ts % 10);
+        ts /= 10;
     }
-    ts_buf[ts_len++] = ']';
-    ts_buf[ts_len++] = ' ';
+    entry->prefix[7] = ']';
 
-    if ((entry->length + ts_len) >= LOGGER_LOG_ENTRY_BUFFER_SIZE)
+    if (entry->length >= LOGGER_LOG_ENTRY_BUFFER_SIZE)
         return false;
 
-    memmove(&entry->msg[ts_len], &entry->msg[0], entry->length);
-    memcpy(&entry->msg[0], ts_buf, ts_len);
-    entry->length += ts_len;
     entry->is_formatted = true;
-
     return true;
 }


### PR DESCRIPTION
## Summary
- allocate fixed-size prefix for each log entry
- include prefix length constant in logger config
- update logger to fill prefix instead of moving message

## Testing
- `mkdir build && cmake --build build -- --no-print-directory` *(fails: could not load cache)*

------
https://chatgpt.com/codex/tasks/task_e_684749dcfafc83238a64c4b9a8442b7e