### PR TITLE
Apply templates to modules

### DIFF
--- a/src/app/test_swc/inc/test_swc.h
+++ b/src/app/test_swc/inc/test_swc.h
@@ -1,8 +1,10 @@
 /**
  * @file test_swc.h
- * @brief Header file for Test Software Component
+ * @brief Interface for the demonstration Test Software Component
  *
- * This file provides the interface for initializing the Test SWC.
+ * This module periodically transmits a short message using the logger and
+ * UART DMA drivers.  It serves as a template for new application software
+ * components and showcases integration of the middleware modules.
  */
 
 #ifndef TEST_SWC_H
@@ -12,11 +14,17 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
+/* Macros and Defines -------------------------------------------------------*/
+
+/* Typedefs -----------------------------------------------------------------*/
+
 /* Exported Functions -------------------------------------------------------*/
 /**
- * @brief Initialize the Test Software Component
+ * @brief Initialize the Test Software Component.
  *
- * This function creates the FreeRTOS task for the Test SWC.
+ * The routine sets up peripheral dependencies and spawns the periodic
+ * demonstration task.  It should be called once during system start-up
+ * after the middleware drivers have been initialized.
  */
 void TestSWC_Init(void);
 

--- a/src/app/test_swc/src/test_swc.c
+++ b/src/app/test_swc/src/test_swc.c
@@ -1,8 +1,10 @@
 /**
  * @file test_swc.c
- * @brief Source file for Test Software Component
+ * @brief Implementation of the Test Software Component
  *
- * This file implements the initialization and task handling for the Test SWC.
+ * The Test SWC periodically allocates a log entry, fills it with a fixed
+ * string and commits it for transmission over the UART DMA driver.  It
+ * demonstrates how the logger can be used from an application task.
  */
 
 /* Includes -----------------------------------------------------------------*/
@@ -18,12 +20,23 @@
 /* Defines ------------------------------------------------------------------*/
 #define TEST_TASK_PERIOD_MS (1U) /**< Period of the demo task in milliseconds */
 
+/* Local Types and Typedefs -------------------------------------------------*/
+
+/* Global Variables ---------------------------------------------------------*/
 /** Test message sent over UART DMA for demonstration purposes. */
 static char testMessage[] = "Hello\r\n";
+
 /* Private Function Prototypes ----------------------------------------------*/
 static void TestTask(void *pvParameters);
 
 /* Public Functions Implementation ------------------------------------------*/
+/**
+ * @brief Initialize the Test Software Component.
+ *
+ * Sets up the UART DMA driver and creates the FreeRTOS task that
+ * periodically logs a demo string.  Should be called once during
+ * application start-up.
+ */
 void TestSWC_Init(void)
 {
     // Initialize the UART DMA module
@@ -35,11 +48,14 @@ void TestSWC_Init(void)
 
 /* Private Functions Implementation -----------------------------------------*/
 /**
- * @brief Task function for Test SWC
+ * @brief Periodic task demonstrating logger usage.
  *
- * This task runs periodically every 100ms.
+ * Allocates a log entry every cycle, copies the demo string into the
+ * entry buffer and commits it for asynchronous transmission.  When no
+ * entry is available the high priority "allocation failed" message is
+ * triggered instead.
  *
- * @param[in] pvParameters Task parameters (not used)
+ * @param[in] pvParameters Unused task parameter.
  */
 static void TestTask(void *pvParameters)
 {

--- a/src/bsw/uart_dma/inc/UartDma.h
+++ b/src/bsw/uart_dma/inc/UartDma.h
@@ -1,8 +1,11 @@
 /**
  * @file UartDma.h
- * @brief Brief description of the UART DMA module
+ * @brief UART transmission driver using DMA
  *
- * Detailed description of the UART DMA module functionality.
+ * The driver offers a simple zero-copy API for sending data over a UART
+ * peripheral.  A lightweight non-blocking lock ensures that transfers are
+ * serialized without blocking the caller.  It is intended for use in
+ * real-time systems where minimal latency is required.
  */
 
 #ifndef UART_DMA_H
@@ -14,38 +17,43 @@
 #include "stm32n6xx_ll_usart.h"
 #include "stm32n6xx_ll_gpio.h"
 #include "stm32n6xx_ll_dma.h"
+
 /* Macros and Defines -------------------------------------------------------*/
-/**
- * @brief Example constant used within the UART DMA module.
- */
-#define EXAMPLE_MODULE_CONSTANT (100U)
 
 /* Typedefs -----------------------------------------------------------------*/
 /**
- * @brief Example structure description
+ * @brief Internal UART DMA driver state
  */
 typedef struct
 {
-    /* Runtime data */
-    uint8_t is_busy;
+    uint8_t is_busy; /**< Flag indicating active DMA transfer */
 } UartDma_Handler_T;
 
 /* Exported Variables -------------------------------------------------------*/
-/** Example global variable used by the module. */
-extern uint32_t g_exampleGlobalVariable;
 
 /* Exported Interfaces ------------------------------------------------------*/
 /**
- * @brief Brief description of example interface function
+ * @brief Initialize the UART DMA driver and its peripherals.
  *
- * Detailed description of the function behavior.
+ * This function configures GPIO pins, the USART peripheral and the DMA
+ * channel required for transmission.  It also creates any internal tasks
+ * used by the driver.
  *
- * @param[in] param1 Description of first parameter
- * @param[out] result Description of output parameter
- *
- * @return Status code
+ * @return true on success, false otherwise.
  */
 bool UartDma_Init(void);
+
+/**
+ * @brief Schedule a buffer for transmission via DMA.
+ *
+ * The function returns immediately after queuing the transfer. If the DMA
+ * channel is busy the call fails and the data should be retried later.
+ *
+ * @param[in] data Pointer to the buffer to transmit.
+ * @param[in] size Number of bytes contained in the buffer.
+ *
+ * @return true if the buffer was accepted for transmission.
+ */
 bool UartDma_Transmit(const uint8_t *data, uint16_t size);
 
 #endif /* UART_DMA_H */

--- a/src/middleware/logger/src/logger.c
+++ b/src/middleware/logger/src/logger.c
@@ -1,8 +1,14 @@
 /**
  * @file logger.c
  * @brief Real-time, dual-priority, ISR-safe, zero-copy logger implementation
+ *
+ * This source file contains the core logic of the logger component. Log
+ * entries are formatted with a timestamp and transmitted using the UART
+ * DMA driver. Both high-priority and normal entries share the same code
+ * path so the implementation remains compact.
  */
 
+/* Includes -----------------------------------------------------------------*/
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
@@ -12,6 +18,13 @@
 #include "task.h"
 #include "cmsis_gcc.h"
 
+/* Defines ------------------------------------------------------------------*/
+
+/* Local Types and Typedefs -------------------------------------------------*/
+
+/* Global Variables ---------------------------------------------------------*/
+
+/* Private Function Prototypes ----------------------------------------------*/
 /* High-priority log entries are defined by the application and
  * registered via ::logger_register_highprio. */
 /** Remove and return the next regular log entry from the queue. */
@@ -22,6 +35,9 @@ static inline void enqueue_normal_log(Logger_Context_T *ctx, Logger_Entry_T *ent
 static inline Logger_Entry_T *peek_normal_log(Logger_Context_T *ctx);
 /** Format a log entry by prepending a timestamp. */
 static bool format_log_entry(Logger_Entry_T *entry);
+
+/* Public Functions Implementation ------------------------------------------*/
+
 /*** Logger API ***/
 /**
  * @brief Allocates a log entry from the static pool.
@@ -191,7 +207,7 @@ void logger_debug_push(Logger_Context_T *ctx, uint32_t value)
     ctx->debug_buffer[idx % LOGGER_DEBUG_BUFFER_SIZE] = value;
 }
 
-/*** Helper Functions ***/
+/* Private Functions Implementation -----------------------------------------*/
 /**
  * @brief Place a log entry into the regular log queue.
  */
@@ -239,6 +255,11 @@ static inline Logger_Entry_T *peek_normal_log(Logger_Context_T *ctx)
 
 /**
  * @brief Format a log entry's prefix with the timestamp.
+ *
+ * The timestamp is converted into a fixed width decimal string enclosed
+ * in square brackets and stored in the entry prefix buffer. The function
+ * does not modify the actual log message.
+ *
  * @param entry Pointer to the Logger_Entry_T to modify.
  * @return true if formatting succeeded.
  */


### PR DESCRIPTION
## Summary
- style logger interface using component template
- apply template sections to logger implementation
- adjust Test SWC files to include template sections
- clean UART DMA headers and sources and follow template
- document modules with detailed doxygen comments

## Testing
- `mkdir build && cmake --build build -- --no-print-directory` *(fails: could not load cache)*

------
https://chatgpt.com/codex/tasks/task_e_6849f8c86b70832394a9df5c1ca12829